### PR TITLE
feat(tokenparser): Make access_token and id_toking parsing configurable

### DIFF
--- a/integrationtests/Host.TestApps.Auth0.IntegrationTests/Auth0IntegrationTests.cs
+++ b/integrationtests/Host.TestApps.Auth0.IntegrationTests/Auth0IntegrationTests.cs
@@ -14,6 +14,7 @@ public class Auth0IntegrationTests : IClassFixture<HostApplication>
             .AddEnvironmentVariables()
             .Build();
 
+        var sub = configuration.GetSection("Auth0:Sub").Get<string>();
         var username = configuration.GetSection("Auth0:Username").Get<string>();
         var password = configuration.GetSection("Auth0:Password").Get<string>();
         
@@ -30,13 +31,19 @@ public class Auth0IntegrationTests : IClassFixture<HostApplication>
             
             await app.WaitForNavigationAsync();
 
-            app.MeEndpoint.Text.Should().Contain(username);
+            app.CurrentPage.Text.Should().Contain(username);
         
             // Assert the user was logged in
             await app.GoTo("/api/echo");
             await Task.Delay(1000);
 
-            app.EchoEndpoint.Text.Should().Contain("Bearer ey");
+            app.CurrentPage.Text.Should().Contain("Bearer ey");
+            
+            // Test ASP.NET Core authorization pipeline
+            await app.GoTo("/custom/me");
+            await Task.Delay(1000);
+
+            app.CurrentPage.Text.Should().Contain(sub);
 
             // Log out
             await app.GoTo("/.auth/end-session");
@@ -49,13 +56,13 @@ public class Auth0IntegrationTests : IClassFixture<HostApplication>
             await app.GoTo("/.auth/me");
             await Task.Delay(1000);
             
-            app.MeEndpoint.Text.Should().NotContain(username);
+            app.CurrentPage.Text.Should().NotContain(username);
             
             // Assert token removed
             await app.GoTo("/api/echo");
             await Task.Delay(1000);
             
-            app.EchoEndpoint.Text.Should().NotContain("Bearer ey");
+            app.CurrentPage.Text.Should().NotContain("Bearer ey");
         }
         finally
         {

--- a/integrationtests/Host.TestApps.Auth0.IntegrationTests/HostApplication.cs
+++ b/integrationtests/Host.TestApps.Auth0.IntegrationTests/HostApplication.cs
@@ -1,6 +1,8 @@
+using System.Security.Claims;
 using OidcProxy.Net.Auth0;
 using OidcProxy.Net.ModuleInitializers;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 
 namespace Host.TestApps.Auth0.IntegrationTests;
@@ -38,6 +40,10 @@ public class HostApplication : IAsyncLifetime, IDisposable
 
         // Build and run..
         _testApi = builder.Build();
+        
+        _testApi
+            .MapGet("/custom/me", async context => await context.Response.WriteAsJsonAsync(context.User.Identity?.Name))
+            .RequireAuthorization();
 
         _testApi.UseOidcProxy();
 

--- a/integrationtests/Host.TestApps.Auth0.IntegrationTests/Pom/App.cs
+++ b/integrationtests/Host.TestApps.Auth0.IntegrationTests/Pom/App.cs
@@ -49,6 +49,5 @@ public class App
     public Auth0SignOutPage Auth0SignOutPage => new(_page);
     
     
-    public MeEndpoint MeEndpoint => new(_page);
-    public EchoEndpoint EchoEndpoint => new(_page);
+    public Endpoint CurrentPage => new(_page);
 }

--- a/integrationtests/Host.TestApps.Auth0.IntegrationTests/Pom/Endpoints.cs
+++ b/integrationtests/Host.TestApps.Auth0.IntegrationTests/Pom/Endpoints.cs
@@ -2,20 +2,6 @@ using PuppeteerSharp;
 
 namespace Host.TestApps.Auth0.IntegrationTests.Pom;
 
-public class MeEndpoint : Endpoint
-{
-    public MeEndpoint(IPage page) : base(page)
-    {
-    }
-}
-
-public class EchoEndpoint : Endpoint
-{
-    public EchoEndpoint(IPage page) : base(page)
-    {
-    }
-}
-
 public class Endpoint
 {
     private readonly IPage _page;

--- a/integrationtests/Host.TestApps.Oidc.IntegrationTests/HostApplication.cs
+++ b/integrationtests/Host.TestApps.Oidc.IntegrationTests/HostApplication.cs
@@ -1,6 +1,7 @@
 using OidcProxy.Net.ModuleInitializers;
 using OidcProxy.Net.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 
 namespace Host.TestApps.Oidc.IntegrationTests;
@@ -27,7 +28,11 @@ public class HostApplication : IAsyncLifetime, IDisposable
         builder.Services.AddOidcProxy(config);
 
         _testApi = builder.Build();
-
+        
+        _testApi
+            .MapGet("/custom/me", async context => await context.Response.WriteAsJsonAsync(context.User.Identity?.Name))
+            .RequireAuthorization();
+        
         _testApi.UseOidcProxy();
 
         _testApi.Urls.Add("https://localhost:8444");

--- a/integrationtests/Host.TestApps.Oidc.IntegrationTests/OidcIntegrationTests.cs
+++ b/integrationtests/Host.TestApps.Oidc.IntegrationTests/OidcIntegrationTests.cs
@@ -19,19 +19,25 @@ public class OidcIntegrationTests : IClassFixture<HostApplication>
             await app.IdSvrLoginPage.BtnYodaLogin.ClickAsync();
             await Task.Delay(2000);
 
-            app.MeEndpoint.Text.Should().Contain(subYoda);
+            app.CurrentPage.Text.Should().Contain(subYoda);
         
             // Assert the user was logged in
             await app.GoTo("/.auth/me");
             await Task.Delay(1000);
 
-            app.MeEndpoint.Text.Should().Contain(subYoda);
-        
+            app.CurrentPage.Text.Should().Contain(subYoda);
+            
+            // Test ASP.NET Core authorization pipeline
+            await app.GoTo("/custom/me");
+            await Task.Delay(1000);
+
+            app.CurrentPage.Text.Should().Contain(subYoda);
+
             // Assert the user was logged in
             await app.GoTo("/api/echo");
             await Task.Delay(1000);
 
-            app.EchoEndpoint.Text.Should().Contain("Bearer ey");
+            app.CurrentPage.Text.Should().Contain("Bearer ey");
 
             // Log out
             await app.GoTo("/.auth/end-session");
@@ -44,13 +50,13 @@ public class OidcIntegrationTests : IClassFixture<HostApplication>
             await app.GoTo("/.auth/me");
             await Task.Delay(1000);
 
-            app.MeEndpoint.Text.Should().NotContain(subYoda);
+            app.CurrentPage.Text.Should().NotContain(subYoda);
             
             // Assert token removed
             await app.GoTo("/api/echo");
             await Task.Delay(1000);
         
-            app.EchoEndpoint.Text.Should().NotContain("Bearer ey");
+            app.CurrentPage.Text.Should().NotContain("Bearer ey");
         }
         finally
         {

--- a/integrationtests/Host.TestApps.Oidc.IntegrationTests/Pom/App.cs
+++ b/integrationtests/Host.TestApps.Oidc.IntegrationTests/Pom/App.cs
@@ -48,6 +48,5 @@ public class App
     public IdSvrLoginPage IdSvrLoginPage => new (_page);
     public IdSvrSignOutPage IdSvrSignOutPage => new (_page);
     
-    public MeEndpoint MeEndpoint => new(_page);
-    public EchoEndpoint EchoEndpoint => new(_page);
+    public Endpoint CurrentPage => new(_page);
 }

--- a/integrationtests/Host.TestApps.Oidc.IntegrationTests/Pom/Endpoints.cs
+++ b/integrationtests/Host.TestApps.Oidc.IntegrationTests/Pom/Endpoints.cs
@@ -2,24 +2,6 @@ using PuppeteerSharp;
 
 namespace Host.TestApps.Oidc.IntegrationTests.Pom;
 
-public class MeEndpoint : Endpoint
-{
-    public static string Uri => "/.auth/me";
-
-    public MeEndpoint(IPage page) : base(page)
-    {
-    }
-}
-
-public class EchoEndpoint : Endpoint
-{
-    public static string Uri = "/echo";
-    
-    public EchoEndpoint(IPage page) : base(page)
-    {
-    }
-}
-
 public class Endpoint
 {
     private readonly IPage _page;

--- a/src/OidcProxy.Net.Auth0/ModuleInitializer.cs
+++ b/src/OidcProxy.Net.Auth0/ModuleInitializer.cs
@@ -67,6 +67,8 @@ public static class ModuleInitializer
             AssignIfNotNull(config.LandingPage, options.SetLandingPage);
             AssignIfNotNull(config.CustomHostName, options.SetCustomHostName);
             AssignIfNotNull(config.CookieName, cookieName => options.CookieName = cookieName);
+            AssignIfNotNull(config.NameClaim, nameClaim => options.NameClaim = nameClaim);
+            AssignIfNotNull(config.RoleClaim, roleClaim => options.RoleClaim = roleClaim);
             
             options.EnableUserPreferredLandingPages = config.EnableUserPreferredLandingPages;
             options.SetAllowedLandingPages(config.AllowedLandingPages);

--- a/src/OidcProxy.Net.Auth0/OidcProxy.Net.Auth0.csproj
+++ b/src/OidcProxy.Net.Auth0/OidcProxy.Net.Auth0.csproj
@@ -6,8 +6,8 @@
         <Nullable>enable</Nullable>
         
         <PackageId>OidcProxy.Net.Auth0</PackageId>
-        <Version>1.1.2</Version>
-        <Version>1.1.2</Version>
+        <Version>1.2.0</Version>
+        <Version>1.2.0</Version>
         <Authors>Albert Starreveld</Authors>
         <Company>GoCloudNative.org</Company>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -21,8 +21,8 @@
         <PackageIcon>logo.png</PackageIcon>
         <SignAssembly>true</SignAssembly>
         <LangVersion>11</LangVersion>
-        <PackageReleaseNotes>Dependency updates:
-- build(deps): bump System.IdentityModel.Tokens.Jwt from 7.3.0 to 7.3.1</PackageReleaseNotes>
+        <PackageReleaseNotes>Feature added:
+            - Introduced `ITokenParser`: Implement this interface to use OidcProxy.Net with reference tokens, for example.</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/OidcProxy.Net.EntraId/ModuleInitializer.cs
+++ b/src/OidcProxy.Net.EntraId/ModuleInitializer.cs
@@ -67,6 +67,8 @@ public static class ModuleInitializer
             AssignIfNotNull(config.LandingPage, options.SetLandingPage);
             AssignIfNotNull(config.CustomHostName, options.SetCustomHostName);
             AssignIfNotNull(config.CookieName, cookieName => options.CookieName = cookieName);
+            AssignIfNotNull(config.NameClaim, nameClaim => options.NameClaim = nameClaim);
+            AssignIfNotNull(config.RoleClaim, roleClaim => options.RoleClaim = roleClaim);
             
             options.EnableUserPreferredLandingPages = config.EnableUserPreferredLandingPages;
             options.SetAllowedLandingPages(config.AllowedLandingPages);

--- a/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
+++ b/src/OidcProxy.Net.EntraId/OidcProxy.Net.EntraId.csproj
@@ -6,23 +6,23 @@
     <Nullable>enable</Nullable>
 
     <PackageId>OidcProxy.Net.EntraId</PackageId>
-    <Version>1.1.2</Version>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Albert Starreveld</Authors>
     <Company>GoCloudNative.org</Company>
     <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
     <Description>A yarp-based authentication gateway for your service mesh.</Description>
     <RepositoryUrl>https://github.com/thecloudnativewebapp/OidcProxy.Net</RepositoryUrl>
-    <PackageTags>BFF, Yarp, Microsoft Entra Ad, Cloud Native</PackageTags>
+    <PackageTags>BFF, Yarp, Microsoft Entra Id, Cloud Native</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>OidcProxy.Net.EntraId</Title>
     <PackageProjectUrl>https://bff.gocloudnative.org</PackageProjectUrl>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>        
     <PackageIcon>logo.png</PackageIcon>        
     <SignAssembly>true</SignAssembly>        
-    <LangVersion>11</LangVersion>        
-    <PackageReleaseNotes>Dependency updates:
-- build(deps): bump System.IdentityModel.Tokens.Jwt from 7.3.0 to 7.3.1</PackageReleaseNotes>
+    <LangVersion>11</LangVersion>
+    <PackageReleaseNotes>Feature added:
+      - Introduced `ITokenParser`: Implement this interface to use OidcProxy.Net with reference tokens, for example.</PackageReleaseNotes>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/OidcProxy.Net.OpenIdConnect/ModuleInitializer.cs
+++ b/src/OidcProxy.Net.OpenIdConnect/ModuleInitializer.cs
@@ -65,6 +65,8 @@ public static class ModuleInitializer
             AssignIfNotNull(config.LandingPage, options.SetLandingPage);
             AssignIfNotNull(config.CustomHostName, options.SetCustomHostName);
             AssignIfNotNull(config.CookieName, cookieName => options.CookieName = cookieName);
+            AssignIfNotNull(config.NameClaim, nameClaim => options.NameClaim = nameClaim);
+            AssignIfNotNull(config.RoleClaim, roleClaim => options.RoleClaim = roleClaim);
             
             options.EnableUserPreferredLandingPages = config.EnableUserPreferredLandingPages;
             options.SetAllowedLandingPages(config.AllowedLandingPages);

--- a/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
+++ b/src/OidcProxy.Net.OpenIdConnect/OidcProxy.Net.OpenIdConnect.csproj
@@ -6,8 +6,8 @@
         <Nullable>enable</Nullable>
 
         <PackageId>OidcProxy.Net.OpenIdConnect</PackageId>
-        <Version>1.1.2</Version>
-        <Version>1.1.2</Version>
+        <Version>1.2.0</Version>
+        <Version>1.2.0</Version>
         <Authors>Albert Starreveld</Authors>
         <Company>GoCloudNative.org</Company>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -21,8 +21,8 @@
         <PackageIcon>logo.png</PackageIcon>
         <SignAssembly>true</SignAssembly>
         <LangVersion>11</LangVersion>
-        <PackageReleaseNotes>Dependency updates:
-- build(deps): bump System.IdentityModel.Tokens.Jwt from 7.3.0 to 7.3.1</PackageReleaseNotes>
+        <PackageReleaseNotes>Feature added:
+- Introduced `ITokenParser`: Implement this interface to use OidcProxy.Net with reference tokens, for example.</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/OidcProxy.Net/Endpoints/CallbackEndpoint.cs
+++ b/src/OidcProxy.Net/Endpoints/CallbackEndpoint.cs
@@ -16,7 +16,7 @@ internal static class CallbackEndpoint
         [FromServices] IRedirectUriFactory redirectUriFactory,
         [FromServices] ProxyOptions proxyOptions,
         [FromServices] IIdentityProvider identityProvider,
-        [FromServices] IJwtParser jwtParser,
+        [FromServices] ITokenParser tokenParser,
         [FromServices] IAuthenticationCallbackHandler authenticationCallbackHandler)
     {
         try
@@ -46,7 +46,7 @@ internal static class CallbackEndpoint
 
             logger.LogLine(context, $"Redirect({proxyOptions.LandingPage})");
 
-            var jwtPayload = jwtParser.ParseAccessToken(tokenResponse.access_token);
+            var jwtPayload = tokenParser.ParseAccessToken(tokenResponse.access_token);
             
             return await authenticationCallbackHandler.OnAuthenticated(context, 
                 jwtPayload, 

--- a/src/OidcProxy.Net/Endpoints/CallbackEndpoint.cs
+++ b/src/OidcProxy.Net/Endpoints/CallbackEndpoint.cs
@@ -16,6 +16,7 @@ internal static class CallbackEndpoint
         [FromServices] IRedirectUriFactory redirectUriFactory,
         [FromServices] ProxyOptions proxyOptions,
         [FromServices] IIdentityProvider identityProvider,
+        [FromServices] IJwtParser jwtParser,
         [FromServices] IAuthenticationCallbackHandler authenticationCallbackHandler)
     {
         try
@@ -45,7 +46,7 @@ internal static class CallbackEndpoint
 
             logger.LogLine(context, $"Redirect({proxyOptions.LandingPage})");
 
-            var jwtPayload = ExtractJwtPayload(tokenResponse.access_token);
+            var jwtPayload = jwtParser.ParseAccessToken(tokenResponse.access_token);
             
             return await authenticationCallbackHandler.OnAuthenticated(context, 
                 jwtPayload, 
@@ -63,10 +64,5 @@ internal static class CallbackEndpoint
     private static string? GetUserPreferredLandingPage(HttpContext context)
     {
         return context.Session.GetUserPreferredLandingPage();
-    }
-
-    private static JwtPayload? ExtractJwtPayload(string? jwt)
-    {
-        return string.IsNullOrEmpty(jwt) ? null : jwt.ParseJwtPayload();
     }
 }

--- a/src/OidcProxy.Net/Endpoints/MeEndpoint.cs
+++ b/src/OidcProxy.Net/Endpoints/MeEndpoint.cs
@@ -7,7 +7,7 @@ namespace OidcProxy.Net.Endpoints;
 internal static class MeEndpoint
 {
     public static async Task<IResult> Get(HttpContext context,
-        [FromServices] IJwtParser jwtParser,
+        [FromServices] ITokenParser tokenParser,
         [FromServices] IClaimsTransformation claimsTransformation)
     {
         if (!context.Session.HasIdToken())
@@ -18,7 +18,7 @@ internal static class MeEndpoint
         context.Response.Headers.CacheControl = $"no-cache, no-store, must-revalidate";
 
         var idToken = context.Session.GetIdToken();
-        var payload = jwtParser.ParseIdToken(idToken);
+        var payload = tokenParser.ParseIdToken(idToken);
         var claims = await claimsTransformation.Transform(payload);
         return Results.Ok(claims);
     }

--- a/src/OidcProxy.Net/Endpoints/MeEndpoint.cs
+++ b/src/OidcProxy.Net/Endpoints/MeEndpoint.cs
@@ -7,6 +7,7 @@ namespace OidcProxy.Net.Endpoints;
 internal static class MeEndpoint
 {
     public static async Task<IResult> Get(HttpContext context,
+        [FromServices] IJwtParser jwtParser,
         [FromServices] IClaimsTransformation claimsTransformation)
     {
         if (!context.Session.HasIdToken())
@@ -17,7 +18,7 @@ internal static class MeEndpoint
         context.Response.Headers.CacheControl = $"no-cache, no-store, must-revalidate";
 
         var idToken = context.Session.GetIdToken();
-        var payload = idToken!.ParseJwtPayload();
+        var payload = jwtParser.ParseIdToken(idToken);
         var claims = await claimsTransformation.Transform(payload);
         return Results.Ok(claims);
     }

--- a/src/OidcProxy.Net/Middleware/OidcProxyAuthenticationSchemeOptions.cs
+++ b/src/OidcProxy.Net/Middleware/OidcProxyAuthenticationSchemeOptions.cs
@@ -2,6 +2,6 @@ using Microsoft.AspNetCore.Authentication;
 
 namespace OidcProxy.Net.Middleware;
 
-public class OidcAuthenticationSchemeOptions : AuthenticationSchemeOptions
+public class OidcProxyAuthenticationSchemeOptions : AuthenticationSchemeOptions
 {
 }

--- a/src/OidcProxy.Net/ModuleInitializers/ProxyConfig.cs
+++ b/src/OidcProxy.Net/ModuleInitializers/ProxyConfig.cs
@@ -5,6 +5,8 @@ public class ProxyConfig
     public string? EndpointName { get; set; }
     public string? ErrorPage { get; set; }
     public string? LandingPage { get; set; }
+    public string? NameClaim { get; set; }
+    public string? RoleClaim { get; set; }
     public IEnumerable<string> AllowedLandingPages { get; set; }
     public bool EnableUserPreferredLandingPages { get; set; } = false;
     public Uri? CustomHostName { get; set; }

--- a/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
+++ b/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
@@ -185,7 +185,7 @@ public class ProxyOptions
     /// Configure a class that converts the token received from the identity-provider to an instance of JwtPayload.
     /// </summary>
     /// <typeparam name="TTokenParser">The type of the class to use to convert the jwt to a JwtPayload.</typeparam>
-    public void AddJwtParser<TTokenParser>() where TTokenParser : class, ITokenParser
+    public void AddTokenParser<TTokenParser>() where TTokenParser : class, ITokenParser
     {
         _applyJwtParser = s => s.AddTransient<ITokenParser, TTokenParser>();
     }

--- a/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
+++ b/src/OidcProxy.Net/ModuleInitializers/ProxyOptions.cs
@@ -28,7 +28,7 @@ public class ProxyOptions
 
     private Action<IServiceCollection> _applyAuthenticationCallbackHandlerRegistration = (s) => s.AddTransient<IAuthenticationCallbackHandler, DefaultAuthenticationCallbackHandler>();
     
-    private Action<IServiceCollection> _applyJwtParser = (s) => s.AddTransient<IJwtParser, JwtParser>();
+    private Action<IServiceCollection> _applyJwtParser = (s) => s.AddTransient<ITokenParser, JwtParser>();
 
     internal Uri? CustomHostName = null;
 
@@ -59,6 +59,16 @@ public class ProxyOptions
     /// redirected to after authenticating successfully.
     /// </summary>
     public bool EnableUserPreferredLandingPages { get; set; } = false;
+
+    /// <summary>
+    /// The name of the claim that represents the username.
+    /// </summary>
+    public string NameClaim { get; set; } = "sub";
+    
+    /// <summary>
+    /// The name of the claim that represents the username.
+    /// </summary>
+    public string RoleClaim { get; set; } = "role";
 
     /// <summary>
     /// Sets a custom page to redirect to when the authentication on the OIDC Server failed.
@@ -174,10 +184,10 @@ public class ProxyOptions
     /// <summary>
     /// Configure a class that converts the token received from the identity-provider to an instance of JwtPayload.
     /// </summary>
-    /// <typeparam name="TJwtParser">The type of the class to use to convert the jwt to a JwtPayload.</typeparam>
-    public void AddJwtParser<TJwtParser>() where TJwtParser : class, IJwtParser
+    /// <typeparam name="TTokenParser">The type of the class to use to convert the jwt to a JwtPayload.</typeparam>
+    public void AddJwtParser<TTokenParser>() where TTokenParser : class, ITokenParser
     {
-        _applyJwtParser = s => s.AddTransient<IJwtParser, TJwtParser>();
+        _applyJwtParser = s => s.AddTransient<ITokenParser, TTokenParser>();
     }
 
     /// <summary>
@@ -274,7 +284,7 @@ public class ProxyOptions
             .TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
                 
         serviceCollection
-            .AddAuthentication(OidcAuthenticationHandler.SchemaName)
-            .AddScheme<OidcAuthenticationSchemeOptions, OidcAuthenticationHandler>(OidcAuthenticationHandler.SchemaName, null);
+            .AddAuthentication(OidcProxyAuthenticationHandler.SchemaName)
+            .AddScheme<OidcProxyAuthenticationSchemeOptions, OidcProxyAuthenticationHandler>(OidcProxyAuthenticationHandler.SchemaName, null);
     }
 }

--- a/src/OidcProxy.Net/OidcProxy.Net.csproj
+++ b/src/OidcProxy.Net/OidcProxy.Net.csproj
@@ -6,12 +6,8 @@
         <Nullable>enable</Nullable>
 
         <PackageId>OidcProxy.Net</PackageId>
-        <Version>1.1.2</Version>
-        <Version>1.1.2</Version>
-        <releaseNotes>
-            Dependency updates:
-                - build(deps): bump System.IdentityModel.Tokens.Jwt from 7.3.0 to 7.3.1
-        </releaseNotes>
+        <Version>1.2.0</Version>
+        <Version>1.2.0</Version>
         <Authors>Albert Starreveld</Authors>
         <Company>GoCloudNative.org</Company>
         <PackageLicenseExpression>LGPL-3.0-only</PackageLicenseExpression>
@@ -24,8 +20,8 @@
         <PackageIcon>logo.png</PackageIcon>
         <SignAssembly>true</SignAssembly>
         <LangVersion>11</LangVersion>
-        <PackageReleaseNotes>Dependency updates:
-- bump System.IdentityModel.Tokens.Jwt from 7.2.0 to 7.3.0</PackageReleaseNotes>
+        <PackageReleaseNotes>Feature added:
+            - Introduced `ITokenParser`: Implement this interface to use OidcProxy.Net with reference tokens, for example.</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/OidcProxy.Net/OpenIdConnect/IJwtParser.cs
+++ b/src/OidcProxy.Net/OpenIdConnect/IJwtParser.cs
@@ -2,8 +2,10 @@ using System.IdentityModel.Tokens.Jwt;
 
 namespace OidcProxy.Net.OpenIdConnect;
 
-public interface IJwtParser
+public interface ITokenParser
 {
+    string GetRoleClaim();
+    string GetNameClaim();
     JwtPayload? ParseAccessToken(string? accessToken);
     JwtPayload? ParseIdToken(string? idToken);
 }

--- a/src/OidcProxy.Net/OpenIdConnect/IJwtParser.cs
+++ b/src/OidcProxy.Net/OpenIdConnect/IJwtParser.cs
@@ -1,0 +1,9 @@
+using System.IdentityModel.Tokens.Jwt;
+
+namespace OidcProxy.Net.OpenIdConnect;
+
+public interface IJwtParser
+{
+    JwtPayload? ParseAccessToken(string? accessToken);
+    JwtPayload? ParseIdToken(string? idToken);
+}

--- a/src/OidcProxy.Net/OpenIdConnect/JwtParser.cs
+++ b/src/OidcProxy.Net/OpenIdConnect/JwtParser.cs
@@ -1,11 +1,22 @@
 using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using System.Text;
+using OidcProxy.Net.ModuleInitializers;
 
 namespace OidcProxy.Net.OpenIdConnect;
 
-internal class JwtParser : IJwtParser
+internal class JwtParser : ITokenParser
 {
+    private readonly ProxyOptions _options;
+
+    public JwtParser(ProxyOptions options)
+    {
+        _options = options;
+    }
+
+    public string GetNameClaim() => _options.NameClaim;
+    
+    public string GetRoleClaim() => _options.RoleClaim;
+
     public JwtPayload? ParseAccessToken(string accessToken) => ParseJwtPayload(accessToken);
 
     public JwtPayload? ParseIdToken(string idToken) => ParseJwtPayload(idToken);

--- a/src/OidcProxy.Net/OpenIdConnect/JwtParser.cs
+++ b/src/OidcProxy.Net/OpenIdConnect/JwtParser.cs
@@ -1,12 +1,22 @@
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using System.Text;
 
 namespace OidcProxy.Net.OpenIdConnect;
 
-internal static class JwtParser
-{   
-    public static JwtPayload? ParseJwtPayload(this string token)
+internal class JwtParser : IJwtParser
+{
+    public JwtPayload? ParseAccessToken(string accessToken) => ParseJwtPayload(accessToken);
+
+    public JwtPayload? ParseIdToken(string idToken) => ParseJwtPayload(idToken);
+
+    private static JwtPayload? ParseJwtPayload(string token)
     {
+        if (string.IsNullOrEmpty(token))
+        {
+            return null;
+        }
+
         var urlEncodedMiddleSection = GetSection(token, 1);
         
         var middleSection = urlEncodedMiddleSection

--- a/unittests/OidcProxy.Net.OpenIdConnect.Tests/OpenIdConnectBffConfigurationTests.cs
+++ b/unittests/OidcProxy.Net.OpenIdConnect.Tests/OpenIdConnectBffConfigurationTests.cs
@@ -21,6 +21,8 @@ public class OpenIdConnectBffConfigurationTests
         },
         ""ErrorPage"": ""/error.aspx"",
         ""LandingPage"": ""/welcome.aspx"",
+        ""RoleClaim"": ""sub"",
+        ""NameClaim"": ""role"",
         ""CustomHostName"": ""www.foobar.org"",
         ""CookieName"": ""bff.custom.cookie"",
         ""SessionIdleTimeout"": ""00:30:00"",
@@ -72,6 +74,8 @@ public class OpenIdConnectBffConfigurationTests
     {
         _deserializedObject?.ErrorPage.Should().NotBeNullOrEmpty();
         _deserializedObject?.LandingPage.Should().NotBeNullOrEmpty();
+        _deserializedObject?.NameClaim.Should().NotBeNullOrEmpty();
+        _deserializedObject?.RoleClaim.Should().NotBeNullOrEmpty();
         _deserializedObject?.CustomHostName.Should().NotBeNull();
         _deserializedObject?.CookieName.Should().NotBeNullOrEmpty();
         _deserializedObject?.SessionIdleTimeout.Should().NotBe(TimeSpan.Zero);

--- a/unittests/OidcProxy.Net.Tests/UnitTests/TokenFactoryTests.cs
+++ b/unittests/OidcProxy.Net.Tests/UnitTests/TokenFactoryTests.cs
@@ -10,7 +10,9 @@ public class TokenFactoryTests
     [InlineData("x.ewogICJzdWIiOiAiMjIzNDU2NzEyIiwKICAibmFtZSI6ICJKb2huIERvZSIsCiAgImlhdCI6IDE1MTYyMzkwMjEKfQ.x")]
     public void WhenPayloadShouldContainPadding_ShouldDecodePayload(string token)
     {
-        var actual = token.ParseJwtPayload();
+        var sut = new JwtParser();
+        
+        var actual = sut.ParseAccessToken(token);
 
         actual.Sub.Should().NotBeNullOrEmpty();
     }
@@ -19,7 +21,9 @@ public class TokenFactoryTests
     [InlineData("x.ewogICJzdWIiOiAiMTIzNDU2NzgiLAogICJuYW1lIjogIkpvaG4gRG9lIiwKICAiaWF0IjogMTUxNjIzOTAyMgp9.x")]
     public void WhenPayloadShouldNotContainPadding_ShouldDecodePayload(string token)
     {
-        var actual = token.ParseJwtPayload();
+        var sut = new JwtParser();
+        
+        var actual = sut.ParseAccessToken(token);
 
         actual.Sub.Should().NotBeNullOrEmpty();
     }
@@ -28,8 +32,9 @@ public class TokenFactoryTests
     public void WhenNoPayload_ShouldReturnNull()
     {
         const string token = "x..y";
-
-        var actual = token.ParseJwtPayload();
+        var sut = new JwtParser();
+        
+        var actual = sut.ParseAccessToken(token);
 
         actual.Should().BeNull();
     }

--- a/unittests/OidcProxy.Net.Tests/UnitTests/TokenFactoryTests.cs
+++ b/unittests/OidcProxy.Net.Tests/UnitTests/TokenFactoryTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using OidcProxy.Net.ModuleInitializers;
 using OidcProxy.Net.OpenIdConnect;
 
 namespace OidcProxy.Net.Tests.UnitTests;
@@ -10,7 +11,7 @@ public class TokenFactoryTests
     [InlineData("x.ewogICJzdWIiOiAiMjIzNDU2NzEyIiwKICAibmFtZSI6ICJKb2huIERvZSIsCiAgImlhdCI6IDE1MTYyMzkwMjEKfQ.x")]
     public void WhenPayloadShouldContainPadding_ShouldDecodePayload(string token)
     {
-        var sut = new JwtParser();
+        var sut = new JwtParser(new ProxyOptions());
         
         var actual = sut.ParseAccessToken(token);
 
@@ -21,7 +22,7 @@ public class TokenFactoryTests
     [InlineData("x.ewogICJzdWIiOiAiMTIzNDU2NzgiLAogICJuYW1lIjogIkpvaG4gRG9lIiwKICAiaWF0IjogMTUxNjIzOTAyMgp9.x")]
     public void WhenPayloadShouldNotContainPadding_ShouldDecodePayload(string token)
     {
-        var sut = new JwtParser();
+        var sut = new JwtParser(new ProxyOptions());
         
         var actual = sut.ParseAccessToken(token);
 
@@ -32,7 +33,7 @@ public class TokenFactoryTests
     public void WhenNoPayload_ShouldReturnNull()
     {
         const string token = "x..y";
-        var sut = new JwtParser();
+        var sut = new JwtParser(new ProxyOptions());
         
         var actual = sut.ParseAccessToken(token);
 


### PR DESCRIPTION
For the use of, for example, reference tokens, you can now implement the `ITokenParser` class.

The token parser has two important methods: the `ParseAccessToken()` method and the `ParseIdToken()` method. This is the class signature:

```csharp

internal class YourTokenParserImplementation : ITokenParser
{
    public string GetNameClaim() => "sub";
    
    public string GetRoleClaim() => "role";

    public JwtPayload? ParseAccessToken(string accessToken)
    {
        // Implement code here that converts the access token to a JwtPayload object.
        // This is an arbitrary example:

        var claims = new[]
        {
            new Claim("access_token", accessToken)
        };

        return new JwtPayload(claims);
    }

    public JwtPayload? ParseIdToken(string idToken) 
    {
        var claims = Todo.GetClaimsFromToken(idToken);

        return new JwtPayload(claims);
    }
}
```

Register the class like so:

```csharp
builder.Services.AddAuth0Proxy(config, o => o.AddTokenParser<YourTokenParserImplementation>());
```